### PR TITLE
Clean up install a bit

### DIFF
--- a/ansible/roles/infrared-install/tasks/main.yml
+++ b/ansible/roles/infrared-install/tasks/main.yml
@@ -1,30 +1,32 @@
 ---
+- name: Install dependencies
+  yum: name={{ item }} state=installed
+  with_items:
+      - git
+      - gcc
+      - libffi-devel
+      - python-virtualenv
+      - libselinux-python
+
 - name: clone infrared
   git:
     repo: https://github.com/redhat-openstack/infrared.git
     dest: "{{ lookup('env','WORKSPACE') }}/infrared"
     force: yes
 
-- name: upgrade pip, setuptools and virtualenv
+- name: create venv with latest pip, setuptools and pbr
   pip:
-    name: "{{ item }}"  
+    virtualenv: "{{ infrared_dir }}/.venv"
+    name: "{{ item }}"
     state: latest
   with_items:
-    - pip
-    - setuptools
-    - virtualenv
-
+      - pip
+      - setuptools
+    
 - name: install infrared
-  shell: |
-    virtualenv .venv
-    source .venv/bin/activate
-  args:
-    chdir: "{{ infrared_dir }}"  
-                 
-- name: install requirements
   shell: |
     source .venv/bin/activate
     pip install .
   args:
-    chdir: "{{ infrared_dir }}"
+    chdir: "{{ infrared_dir }}" 
 

--- a/ansible/vars/main.yml
+++ b/ansible/vars/main.yml
@@ -1,5 +1,5 @@
 version: 13
 build: passed_phase2
-hypervisor: 
+hypervisor:
 host_key: ~/.ssh/id_rsa
 


### PR DESCRIPTION
- Don't assume the dependencies needed for infrared are already installed
- Use the pip library to manage the virtualenv and its setup.
- Update setuptools and pip in the venv so we dont get stuck in rpm
  hell on the host.

Signed-off-by: Chuck Short <chucks@redhat.com>